### PR TITLE
Add basic React Native tabbed app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/App.js
+++ b/App.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import MapView from 'react-native-maps';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+const services = [
+  { key: 'ride', title: 'Viaje' },
+  { key: 'food', title: 'Comida' },
+  { key: 'package', title: 'Envío' },
+  { key: 'market', title: 'Mercado' },
+  { key: 'reserve', title: 'Reservas' },
+  { key: 'bike', title: 'Bicicletas' },
+];
+
+function GridScreen() {
+  return (
+    <FlatList
+      data={services}
+      numColumns={2}
+      keyExtractor={(item) => item.key}
+      contentContainerStyle={styles.grid}
+      renderItem={({ item }) => (
+        <TouchableOpacity style={styles.card}>
+          <Text style={styles.cardText}>{item.title}</Text>
+        </TouchableOpacity>
+      )}
+    />
+  );
+}
+
+function MapScreen() {
+  return (
+    <View style={styles.mapContainer}>
+      <MapView style={StyleSheet.absoluteFillObject} />
+    </View>
+  );
+}
+
+function UserScreen() {
+  return (
+    <View style={styles.center}>
+      <Text style={styles.title}>Perfil de Usuario</Text>
+    </View>
+  );
+}
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Servicios" component={GridScreen} />
+        <Tab.Screen name="Mapa" component={MapScreen} />
+        <Tab.Screen name="Usuario" component={UserScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    padding: 20,
+  },
+  card: {
+    flex: 1,
+    margin: 10,
+    height: 100,
+    backgroundColor: '#ededed',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+  },
+  cardText: {
+    fontSize: 18,
+  },
+  mapContainer: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+  },
+});

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "SeiferNew",
+  "displayName": "SeiferNew"
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['module:metro-react-native-babel-preset'],
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "seifernew",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@react-navigation/bottom-tabs": "^7.4.0",
+    "@react-navigation/native": "^7.1.14",
+    "mapbox-gl": "^3.13.0",
+    "react": "^19.1.0",
+    "react-native": "^0.80.0",
+    "react-native-gesture-handler": "^2.26.0",
+    "react-native-maps": "^1.24.3",
+    "react-native-safe-area-context": "^5.5.0",
+    "react-native-screens": "^4.11.1",
+    "react-native-vector-icons": "^10.2.0"
+  },
+  "devDependencies": {
+    "metro-react-native-babel-preset": "^0.77.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create React Native starter files
- implement 3-tab layout with services grid, map and user profile
- ignore Node modules and lock file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68577e179144832e83c3f397e48bc048